### PR TITLE
missing atom test & pagination fix

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,4 +62,3 @@ html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
 
 html_logo = "_static/logo-3m.svg"
-

--- a/docs/umls-info.rst
+++ b/docs/umls-info.rst
@@ -7,4 +7,3 @@ Information regarding the sources contained in UMLS Metathesaurus.
 
 * `Vocabulary Documentation <https://www.nlm.nih.gov/research/umls/sourcereleasedocs/index.html>`_
 * `Basic UMLS License Agreement <https://uts.nlm.nih.gov/uts/assets/LicenseAgreement.pdf>`_
-

--- a/tests/api/test_metathesaurus.py
+++ b/tests/api/test_metathesaurus.py
@@ -50,21 +50,33 @@ def test_get_relations(api, kwargs, rel_count):
 
 
 @pytest.mark.parametrize(
-    ("kwargs", "atom_count"),
+    ("kwargs", "atom_count", "expected_aui"),
     (
-        (dict(cui="C3472551", includeObsolete=True, includeSuppressible=True), 5),
-        (dict(cui="C0009044", language="ENG"), 14),
+        (dict(cui="C3472551"), 0, None),
+        (
+            dict(cui="C3472551", includeObsolete=True, includeSuppressible=True),
+            5,
+            "A32611696",
+        ),
+        (dict(cui="C0009044", language="ENG"), 14, "A0542680"),
+        (dict(cui="C1260922", language="ENG"), 59, "A33193650"),
+        (dict(cui="C1260922", language="ENG", pageSize=1000), 59, "A33193650"),
     ),
 )
-def test_get_atoms_for_cui(api, kwargs, atom_count):
-    data = list(api.get_atoms_for_cui(**kwargs))
-    assert data
-    assert len(data) == atom_count
+def test_get_atoms_for_cui(api, kwargs, atom_count, expected_aui):
+    atoms = list(api.get_atoms_for_cui(**kwargs))
+    assert atoms is not None
+    assert len(atoms) == atom_count
+    if atoms:
+        assert expected_aui in set(a.get("ui") for a in atoms)
 
 
 @pytest.mark.parametrize(
     ("aui",),
-    (("A0243916",),),
+    (
+        ("A0243916",),
+        ("A33193650",),
+    ),
 )
 def test_get_atom(api, aui):
     atom = api.get_atom(aui=aui)

--- a/tests/lookup/test_desc.py
+++ b/tests/lookup/test_desc.py
@@ -110,7 +110,7 @@ def test_get_synonyms(api, kwargs, expected_names):
 
 
 @pytest.mark.parametrize(
-    ("kwargs", "expected_syns"),
+    ("kwargs", "expected"),
     (
         (
             dict(source_vocab="CPT", concept_id="44950"),
@@ -217,9 +217,15 @@ def test_get_synonyms(api, kwargs, expected_names):
                 "Unspecified precerebral artery, with cerebral infarction",
             ],
         ),
+        (
+            dict(source_vocab="ICD10CM", concept_id="R06", language="ENG"),
+            "Abnormal respiratory system physiology",
+        ),
     ),
 )
-def test_find_synonyms(api, kwargs, expected_syns):
+def test_find_synonyms(api, kwargs, expected):
     syns = find_synonyms(api, **kwargs)
-    # assert len(syns) == len(expected_syns)
-    assert syns == expected_syns
+    if isinstance(expected, str):
+        assert expected in syns
+    else:
+        assert syns == expected

--- a/umlsrat/api/rat_session.py
+++ b/umlsrat/api/rat_session.py
@@ -5,8 +5,8 @@ import os
 from os.path import expanduser
 from typing import Optional, Any, Dict, List, Iterator
 
-from ratelimit import limits, RateLimitException
 from backoff import on_exception, expo
+from ratelimit import limits, RateLimitException
 from requests import Session, HTTPError, Response
 from requests.adapters import HTTPAdapter
 from requests_cache import CachedSession
@@ -218,6 +218,9 @@ class MetaThesaurusSession(object):
         if not response_json:
             return
 
+        # get page count from first call
+        page_count = response_json.get("pageCount", None)
+
         if "pageNumber" not in response_json:
             raise ValueError(
                 "Expected pagination fields in response:\n"
@@ -243,7 +246,7 @@ class MetaThesaurusSession(object):
                 if n_yielded == max_results:
                     return
 
-            if response_json.get("pageCount", None) == params["pageNumber"]:
+            if page_count == params["pageNumber"]:
                 # no more pages
                 return
 


### PR DESCRIPTION
It seems that in this case, the resulting value for "pageCount" changes from call to call. Therefore, we take the "pageCount" value from the first call. 