### PR TITLE
get latest umls version and use it by default

### DIFF
--- a/tests/api/test_session.py
+++ b/tests/api/test_session.py
@@ -1,12 +1,11 @@
 import multiprocessing
+import re
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from time import sleep
 from urllib.parse import urlparse
 
 import pytest
 from requests import HTTPError
-
-from umlsrat import const
 
 
 class ResponseCodeHandler(BaseHTTPRequestHandler):
@@ -74,17 +73,17 @@ def test_get_single_result(mt_session):
 
 
 def test_include_flags(mt_session):
-    uri = f"https://uts-ws.nlm.nih.gov/rest/search/{const.DEFAULT_UMLS_VERSION}?string=10937761000119101&sabs=SNOMEDCT_US&searchType=exact&inputType=sourceUi"
+    uri = f"https://uts-ws.nlm.nih.gov/rest/search/current?string=10937761000119101&sabs=SNOMEDCT_US&searchType=exact&inputType=sourceUi"
     res = list(mt_session.get_results(uri))
 
-    include_uri = f"https://uts-ws.nlm.nih.gov/rest/search/{const.DEFAULT_UMLS_VERSION}?includeObsolete=True&includeSuppressible=True&string=10937761000119101&sabs=SNOMEDCT_US&searchType=exact&inputType=sourceUi"
+    include_uri = f"https://uts-ws.nlm.nih.gov/rest/search/current?includeObsolete=True&includeSuppressible=True&string=10937761000119101&sabs=SNOMEDCT_US&searchType=exact&inputType=sourceUi"
     include_res = list(mt_session.get_results(include_uri))
 
     assert len(include_res) >= len(res)
 
 
 def test_cache(mt_session):
-    concept_url = f"https://uts-ws.nlm.nih.gov/rest/content/{const.DEFAULT_UMLS_VERSION}/CUI/C0009044"
+    concept_url = "https://uts-ws.nlm.nih.gov/rest/content/current/CUI/C0009044"
     res1 = mt_session.get_single_result(concept_url)
     # modify the result
     res1["foo"] = "bar"
@@ -92,3 +91,8 @@ def test_cache(mt_session):
     res2 = mt_session.get_single_result(concept_url)
     # make sure that we didn't get the modified object
     assert res1 != res2
+
+
+def test_get_current_version(mt_session):
+    version = mt_session.get_current_version()
+    assert re.match(r"^\d\d\d\d[A-Z][A-Z]", version)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ import random
 
 import pytest
 
-from umlsrat import const
 from umlsrat.api.metathesaurus import MetaThesaurus
 from umlsrat.api.rat_session import MetaThesaurusSession
 from umlsrat.util import args_util
@@ -20,7 +19,7 @@ def pytest_addoption(parser):
         "--umls-version",
         type=str,
         help="UMLS version",
-        default=const.DEFAULT_UMLS_VERSION,
+        default=None,
     )
 
 

--- a/umlsrat/api/metathesaurus.py
+++ b/umlsrat/api/metathesaurus.py
@@ -36,9 +36,10 @@ class MetaThesaurus(object):
         if umls_version:
             self.umls_version = umls_version
         else:
-            self.umls_version = const.DEFAULT_UMLS_VERSION
+            self.umls_version = self.session.get_current_version()
+            self._logger.info("Using latest UMLS version '%s'", self.umls_version)
 
-        self._rest_uri = "https://uts-ws.nlm.nih.gov/rest"
+        self._rest_uri = const.UMLS_REST_ENDPOINT
 
         if self.session.use_cache and self.umls_version == "current":
             # may want to simply disable caching if version is 'current'
@@ -62,8 +63,8 @@ class MetaThesaurus(object):
         group.add_argument(
             "--umls-version",
             type=str,
-            help="UMLS version to use",
-            default=const.DEFAULT_UMLS_VERSION,
+            help="UMLS version to use. By default, fetch the exact current version string.",
+            default=None,
         )
 
         return parser
@@ -500,7 +501,6 @@ class MetaThesaurus(object):
         source_vocab: str,
         concept_id: str,
     ) -> Iterator[Dict]:
-
         """
         Get source asserted parents
 

--- a/umlsrat/api/rat_session.py
+++ b/umlsrat/api/rat_session.py
@@ -97,6 +97,26 @@ class MetaThesaurusSession(object):
 
         self.session = _configure_session(self.session)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.session.close()
+
+    def get_current_version(self) -> str:
+        """
+        Get the precise current version of UMLS. (e.g. 2023AA)
+        """
+        # use a temp session to ensure cache is disabled
+        with MetaThesaurusSession(api_key=self._api_key, use_cache=False) as s:
+            # get info for "Controlled Vocabulary"
+            content_base = const.UMLS_REST_ENDPOINT + "/content/"
+            result = s.get_single_result(content_base + "current/CUI/C0282503")
+            # parse version from atoms url
+            version = result["atoms"][len(content_base) :].split("/")[0]
+
+        return version
+
     @staticmethod
     def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         """

--- a/umlsrat/const.py
+++ b/umlsrat/const.py
@@ -1,4 +1,4 @@
-DEFAULT_UMLS_VERSION = "2023AA"
+UMLS_REST_ENDPOINT = "https://uts-ws.nlm.nih.gov/rest"
 
 API_KEY_ENV_VAR = "UMLS_API_KEY"
 


### PR DESCRIPTION
Currently, a default version is hard-coded. Instead we programmatically determine the precise latest version string and use that. 